### PR TITLE
Log Events Defaults

### DIFF
--- a/clogMonitor/src/components/LogEvents.js
+++ b/clogMonitor/src/components/LogEvents.js
@@ -18,9 +18,9 @@ const LogEvents = () => {
     const token = sessionStorage.getItem("token");
 
     const now = new Date();
-    const oneHourOffset = 60 * 60 * 1000; // 1 hour * 60 min/hr * 60 sec/min * 1000 ms/sec
-    const oneHourAgo = new Date(now.getTime() - oneHourOffset);
-    const defaultStart = oneHourAgo.toISOString().substring(0, 19).replace("T", " ");
+    const offset = 24 * 60 * 60 * 1000; // 24 hour * 60 min/hr * 60 sec/min * 1000 ms/sec
+    const before = new Date(now.getTime() - offset);
+    const defaultStart = before.toISOString().substring(0, 19).replace("T", " ");
     const defaultEnd = now.toISOString().substring(0, 19).replace("T", " ");
 
     const defaultQuery = {

--- a/clogMonitor/src/components/LogEvents.js
+++ b/clogMonitor/src/components/LogEvents.js
@@ -17,6 +17,12 @@ const LogEvents = () => {
     const [needTryAgain, setNeedTryAgain] = React.useState(false);
     const token = sessionStorage.getItem("token");
 
+    const now = new Date();
+    const oneHourOffset = 60 * 60 * 1000; // 1 hour * 60 min/hr * 60 sec/min * 1000 ms/sec
+    const oneHourAgo = new Date(now.getTime() - oneHourOffset);
+    const defaultStart = oneHourAgo.toISOString().substring(0, 19).replace("T", " ");
+    const defaultEnd = now.toISOString().substring(0, 19).replace("T", " ");
+
     const defaultQuery = {
         sev_info: "true", // boolean
         sev_succ: "true", // boolean
@@ -30,6 +36,8 @@ const LogEvents = () => {
         stop: "true",
         security: "true",
         heartbeat: "true",
+        creation_time_start: defaultStart, // Timestamp
+        creation_time_end: defaultEnd, // Timestamp
     }
 
     const attemptQuery = (params, filters={}) => {

--- a/clogMonitor/src/components/LogEventsFilters.js
+++ b/clogMonitor/src/components/LogEventsFilters.js
@@ -62,8 +62,8 @@ const LogEventsFilters = ({ dataSetHandler }) => {
     const [processServices, setProcessServices] = React.useState([]);
     const [process_service, setProcess_service] = React.useState("All");
     // Datetime states (Dates stored are as local time strings, not UTC time)
-    const oneHourOffset = 60 * 60 * 1000; // 1 hour * 60 min/hr * 60 sec/min * 1000 ms/sec
-    const [startTime, setStartTime] = React.useState(dateTimeStringFromNow(oneHourOffset));
+    const defaultOffset = 24 * 60 * 60 * 1000; // 24 hour * 60 min/hr * 60 sec/min * 1000 ms/sec
+    const [startTime, setStartTime] = React.useState(dateTimeStringFromNow(defaultOffset));
     const [endTime, setEndTime] = React.useState(dateTimeStringFromNow(0));
 
     // On component load, try to find and load cached filters

--- a/clogMonitor/src/components/LogEventsFilters.js
+++ b/clogMonitor/src/components/LogEventsFilters.js
@@ -7,39 +7,21 @@ import TimeRange from "./TimeRange";
 import './LogEvents.css'
 
 /**
- * Returns the current datetime as a valid string for datetime-local inputs
+ * Returns the current datetime minus a given offset as a valid string for datetime-local inputs
  * 
- * @returns {string} 
+ * @param {Number} offset - integer number of ms before current time to return
+ * 
+ * @returns {string} (Now - offset) as a datetime-local valid string
  * @see {@link https://developer.mozilla.org/en-US/docs/Web/HTML/Date_and_time_formats#local_date_and_time_strings}
  */
-const getCurrentDateTimeString = () => {
+const dateTimeStringFromNow = (offset=0) => {
     let now = new Date();
-    let offset = now.getTimezoneOffset() * 60000;
-    let adjustedDate = new Date(now.getTime() - offset);
+    let tzOffset = now.getTimezoneOffset() * 60000;
+    let adjustedDate = new Date(now.getTime() - tzOffset - offset);
     let formattedDate = adjustedDate.toISOString().substring(0, 19);
     return formattedDate;
 };
 
-/**
- * Returns the default start datetime or end datetime depending on if i is 0 or 1, in local time
- * 
- * @param {0 | 1} i 0 if requesting default start, 1 if requesting default end
- * @returns {string} The default local datetime string formatted for datetime-local inputs
- * @see {@link https://developer.mozilla.org/en-US/docs/Web/HTML/Date_and_time_formats#local_date_and_time_strings}
- */
-const getDefaultDateTimeString = (i) => {
-    // Uses min time for start and max time for end
-    // unless there is no data, in which we use current datetime
-    const mmtime = getActualMinMaxTime();
-    if(mmtime) {
-        // mmtime is in utc, we need offset;
-        let adjustedDates = mmtime.map((d) => new Date(d.getTime() + (60000 * d.getTimezoneOffset())));
-        // use 23 instead of 19 for ms precision
-        return adjustedDates[i].toISOString().substring(0, 19);
-    } else {
-        return getCurrentDateTimeString();
-    }
-}
 
 /**
  * The filters for the Log Events Table.
@@ -80,8 +62,9 @@ const LogEventsFilters = ({ dataSetHandler }) => {
     const [processServices, setProcessServices] = React.useState([]);
     const [process_service, setProcess_service] = React.useState("All");
     // Datetime states (Dates stored are as local time strings, not UTC time)
-    const [startTime, setStartTime] = React.useState(getDefaultDateTimeString(0));
-    const [endTime, setEndTime] = React.useState(getDefaultDateTimeString(1));
+    const oneHourOffset = 60 * 60 * 1000; // 1 hour * 60 min/hr * 60 sec/min * 1000 ms/sec
+    const [startTime, setStartTime] = React.useState(dateTimeStringFromNow(oneHourOffset));
+    const [endTime, setEndTime] = React.useState(dateTimeStringFromNow(0));
 
     // On component load, try to find and load cached filters
     useEffect(() => {

--- a/clogMonitor/src/components/LogEventsTable.js
+++ b/clogMonitor/src/components/LogEventsTable.js
@@ -19,7 +19,7 @@ const columns = [
         type: 'number',
         align: 'left',
         headerAlign: 'left',
-        flex: 2,
+        flex: 3,
         valueFormatter: (params) => {
             // Info < 20, Success >= 20 and < 30, Warning >= 30 and < 50, Error >= 50
             const val = params.value;
@@ -39,7 +39,7 @@ const columns = [
         field: 'priority', 
         headerName: 'Priority', 
         type: 'number',
-        flex: 2,
+        flex: 3,
         align: 'left',
         headerAlign: 'left',
         valueFormatter: (params) => {
@@ -54,7 +54,7 @@ const columns = [
             return "High"
         },
     },
-    { field: 'categoryName', headerName: 'Category', flex: 2 },
+    { field: 'categoryName', headerName: 'Category', flex: 3 },
     { 
         field: 'creationTime', 
         type: 'dateTime',
@@ -67,8 +67,8 @@ const columns = [
     },
     { field: 'application', headerName: 'Application', flex: 4 },
     // EVENT_CONTEXT is the key for PROCESS, COMPONENT is the key for SERVICE
-    { field: 'eventContext', headerName: 'Process/Service', flex: 5 },
-    { field: 'activity', headerName: 'Activity', flex: 6 },
+    { field: 'eventContext', headerName: 'Process/Service', flex: 4 },
+    { field: 'activity', headerName: 'Activity', flex: 5 },
     {
         field: 'actions',
         headerName: 'Log Event',

--- a/clogMonitor/src/components/LogEventsTable.js
+++ b/clogMonitor/src/components/LogEventsTable.js
@@ -106,7 +106,7 @@ const gridToolbar = () => {
  * @returns {React.ElementType}
  */
 const LogEventsTable = ({data, loading, error}) => {
-    const [pageSize, setPageSize] = useState(5)
+    const [pageSize, setPageSize] = useState(10)
 
     return (
         <div className='log-events-table-container'>
@@ -116,7 +116,7 @@ const LogEventsTable = ({data, loading, error}) => {
                 error={error ? true : undefined}
                 columns={columns}
                 pageSize={pageSize}
-                rowsPerPageOptions={[5, 10, 25, 50, 100]}
+                rowsPerPageOptions={[10, 25, 50, 100]}
                 onPageSizeChange={(newSize) => setPageSize(newSize)}
                 getRowId={(row) => row["globalInstanceId"]}
                 components={{

--- a/clogMonitor/src/components/LogEventsTable.js
+++ b/clogMonitor/src/components/LogEventsTable.js
@@ -125,7 +125,7 @@ const LogEventsTable = ({data, loading, error}) => {
                 }}
                 initialState={{
                     sorting: {
-                      sortModel: [{ field: 'creationTime', sort: 'desc' }],
+                      sortModel: [{ field: 'creationTime', sort: 'asc' }],
                     },
                 }}
             />


### PR DESCRIPTION
## Changes
- Changed the default TimeRange values to be from a day ago to current time.
- Changed defaultQuery in LogEvents to match the default filters
- Uses the following column flex values in LogEventsTable: 3, 3, 3, 5, 4, 4, 5
- Changed default pageSize in LogEventsTable to 10, remove 5 from rowsPerPageOptions
- Uses ascending sort to have dates in chronological order by default

## Link to relevant github issue
https://github.com/david-fisher/320-S22-Track1/issues/117

## Checklist before submission
- [x] I have performed a self-review of my code
- [x] I have requested a review from a relevant classmate
- [x] I have checked the entire app builds clean locally without errors or warnings
- [x] I have added any new tests to the appropriate directories (None required)
- [ ] I have waited for Jenkins status tests to finish and pass